### PR TITLE
Change special use mailbox for Junk to use the Spam mailbox

### DIFF
--- a/templates/10-mail.conf.j2
+++ b/templates/10-mail.conf.j2
@@ -6,7 +6,7 @@ namespace inbox {
 	mailbox Drafts {
 		special_use = \Drafts
 	}
-	mailbox Junk {
+	mailbox Spam {
 		special_use = \Junk
 	}
 	mailbox Sent {


### PR DESCRIPTION
The example on the Dovecot site is here: https://wiki.dovecot.org/MailboxSettings
Since we use 'Spam' as the designated mailbox, changing this now makes a "flame icon" next to "Spam" appear and it's used for "Junk".

Note: ```/etc/dovecot/conf.d/15-mailboxes.conf``` (which is installed by Dovecot package) seems to have similar items in it, but is not under ansible control. Is it duplicated? It also has to be edited like this, then you restart Dovecot.